### PR TITLE
Improvement of OPH_MERGECUBES2 

### DIFF
--- a/etc/operators_xml/OPH_MERGECUBES2_operator_1.0.xml
+++ b/etc/operators_xml/OPH_MERGECUBES2_operator_1.0.xml
@@ -13,6 +13,8 @@ data cubes can be merged. A new implicit dimension will be created.
 [Parameters]
 - cubes : name of the datacubes to merge. The names must be in PID format.
           Multiple-value field: list of cubes separated by &quot;|&quot; can be provided.
+          The first cube could include an implicit dimension named as the argument &quot;dim&quot; and, in this case,
+          no new dimension is created, but it is simply extended with new values.
 - schedule : scheduling algorithm. The only possible value is 0, for a static linear block distribution of resources.
 - container : name of the container to be used to store the output cube; by default it is the input container.
 - dim : name of the new dimension to be created; by default a unique random name is chosen.

--- a/etc/operators_xml/OPH_MERGECUBES2_operator_1.0.xml
+++ b/etc/operators_xml/OPH_MERGECUBES2_operator_1.0.xml
@@ -9,6 +9,8 @@ Data Process.
 It merges the measures of n input datacubes with the same fragmentation structure and
 creates a new datacube with the union of the n measures. NOTE: only single measure 
 data cubes can be merged. A new implicit dimension will be created.
+A cube is allowed to have an additional implicit dimension and, in this case,
+that dimension will be extended by merging the other cubes.
 
 [Parameters]
 - cubes : name of the datacubes to merge. The names must be in PID format.
@@ -23,7 +25,7 @@ data cubes can be merged. A new implicit dimension will be created.
 - description : additional description to be associated with the output cube.
 - order : criteria on which input cubes are ordered before merging:
           - source : cubes are ordered by source, provided that level is 0
-          By default input cubes are not ordered.
+          By default, the input cubes are sorted in descending order with the number of dimensions.
         
 [System parameters]    
 - exec_mode : operator execution mode. Possible values are async (default) for

--- a/etc/primitives_xml/OPH_INTERLACE2_primitive_1.0.xml
+++ b/etc/primitives_xml/OPH_INTERLACE2_primitive_1.0.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE primitive SYSTEM "ophidiaprimitive.dtd">
+<primitive name="oph_interlace2" version="1.0">
+    <info>
+        <abstract>[Behaviour]
+Interlaces multiple input measures into a single output measure. It requires at least two measures, otherwise it returns an error. For each measure an input type should be specified. Given two input arrays A(a1, a2, ..., an) and B(b1, b2, ..., bn), the resulting array will be C(a1, b1, a2, b2, ..., an, bn).
+
+[Parameters]
+- input measure type : Ophidia typing. Supported types are enumerations of:
+					&apos;oph_double&apos;;
+					&apos;oph_float&apos;;
+					&apos;oph_long&apos;;
+					&apos;oph_int&apos;;
+					&apos;oph_short&apos;;
+					&apos;oph_byte&apos;.
+- output measure type : Ophidia typing. Supported types are:
+					&apos;oph_double&apos;;
+					&apos;oph_float&apos;;
+					&apos;oph_long&apos;;
+					&apos;oph_int&apos;;
+					&apos;oph_short&apos;;
+					&apos;oph_byte&apos;.
+- binary count list : binary array of long long counters representing the sizes of each block to be taken from each input measure to build the result. By default, each size is set to 1 for each measure.
+- measure : input measure. This argument can be specified multiple times.
+
+[Return type]
+Binary-array.
+
+[Examples]
+Interlace three measures using the count list count_list.
+oph_interlace2(&apos;OPH_DOUBLE|OPH_FLOAT|OPH_INT&apos;,&apos;OPH_DOUBLE,OPH_FLOAT,OPH_INT&apos;,count_list,a.measure,b.measure,c.measure)</abstract>
+        <author>CMCC Foundation</author>
+        <category>Core Array</category>
+        <creationdate>23/05/2023</creationdate>
+        <license url="http://www.gnu.org/licenses/gpl.txt">GPLv3</license>
+        <return type="binary-array" />
+        <operation type="reduce"/>
+    </info>
+    <args>
+		<argument type="oph_type" mandatory="yes" values="'oph_double'|'oph_float'|'oph_int'|'oph_long'|'oph_short'|'oph_byte'" multivalue="yes">input measure type</argument>
+		<argument type="oph_type" mandatory="yes" values="'oph_double'|'oph_float'|'oph_int'|'oph_long'|'oph_short'|'oph_byte'">output measure type</argument>
+		<argument type="binary-array" mandatory="yes" default="NULL">binary count list</argument>
+		<multi-argument type="binary-array" mandatory="yes" mintimes="1">measure</multi-argument>
+    </args>
+</primitive>

--- a/include/drivers/OPH_MERGECUBES2_operator.h
+++ b/include/drivers/OPH_MERGECUBES2_operator.h
@@ -33,8 +33,8 @@
 #define OPH_MERGECUBES2_QUERY_OPERATION OPH_IOSERVER_SQ_BLOCK(OPH_IOSERVER_SQ_OPERATION, OPH_IOSERVER_SQ_OP_CREATE_FRAG_SELECT) OPH_IOSERVER_SQ_BLOCK(OPH_IOSERVER_SQ_ARG_FRAG, "%s")
 
 #define OPH_MERGECUBES2_QUERY_SELECT  OPH_IOSERVER_SQ_BLOCK(OPH_IOSERVER_SQ_ARG_FIELD, "%s")
-#define OPH_MERGECUBES2_ARG_SELECT			"frag%d.%s|oph_interlace('%s','%s',%s)"
-#define OPH_MERGECUBES2_ARG_SELECT_CMPR			"frag%d.%s|oph_compress('','',oph_interlace('%s','%s',%s))"
+#define OPH_MERGECUBES2_ARG_SELECT			"frag%d.%s|oph_interlace2('%s','%s',?,%s)"
+#define OPH_MERGECUBES2_ARG_SELECT_CMPR			"frag%d.%s|oph_compress('','',oph_interlace2('%s','%s',?,%s))"
 #define OPH_MERGECUBES2_ARG_SELECT_TYPE			"oph_%s"
 #define OPH_MERGECUBES2_ARG_SELECT_PART			"frag%d.%s"
 #define OPH_MERGECUBES2_ARG_SELECT_PART_CMPR		"oph_uncompress('','',frag%d.%s)"
@@ -105,6 +105,7 @@ struct _OPH_MERGECUBES2_operator_handle {
 	char *dim_type;
 	int number;
 	short int execute_error;
+	int ensamble_size;
 };
 typedef struct _OPH_MERGECUBES2_operator_handle OPH_MERGECUBES2_operator_handle;
 

--- a/include/ophidiadb/query/oph_odb_cube_query.h
+++ b/include/ophidiadb/query/oph_odb_cube_query.h
@@ -100,7 +100,8 @@
 
 #define MYSQL_QUERY_CUBE_UPDATE_OPHIDIADB_TUPLEXFRAGMENT	"UPDATE datacube SET tuplexfragment = %d WHERE iddatacube = %d"
 
-#define MYSQL_QUERY_ORDER_CUBE_BY_SOURCE				"SELECT idcontainer, iddatacube FROM datacube INNER JOIN source ON datacube.idsource = source.idsource WHERE level = 0 AND iddatacube IN (%s) ORDER BY uri ASC;"
+#define MYSQL_QUERY_ORDER_CUBE_BY_NDIM					"SELECT idcontainer, datacube.iddatacube, COUNT(*) AS ndim FROM datacube INNER JOIN cubehasdim ON datacube.iddatacube = cubehasdim.iddatacube INNER JOIN dimensioninstance ON cubehasdim.iddimensioninstance = dimensioninstance.iddimensioninstance WHERE size > 0 AND datacube.iddatacube IN (%s) GROUP BY datacube.iddatacube ORDER BY ndim DESC;"
+#define MYSQL_QUERY_ORDER_CUBE_BY_SOURCE				"SELECT idcontainer, datacube.iddatacube, COUNT(*) AS ndim FROM datacube INNER JOIN cubehasdim ON datacube.iddatacube = cubehasdim.iddatacube INNER JOIN dimensioninstance ON cubehasdim.iddimensioninstance = dimensioninstance.iddimensioninstance INNER JOIN source ON datacube.idsource = source.idsource WHERE size > 0 AND datacube.level = 0 AND datacube.iddatacube IN (%s) GROUP BY datacube.iddatacube ORDER BY ndim DESC, uri ASC;"
 
 #define MYSQL_QUERY_CUBE_UPDATE_OPHIDIADB_CUBE_MS		"UPDATE datacube SET idmissingvalue = %d WHERE iddatacube = %d;"
 #define MYSQL_QUERY_CUBE_RETRIEVE_OPHIDIADB_CUBE_MS		"SELECT idmissingvalue, measure FROM `datacube` WHERE iddatacube = %d;"

--- a/src/drivers/OPH_MERGECUBES2_operator.c
+++ b/src/drivers/OPH_MERGECUBES2_operator.c
@@ -186,6 +186,7 @@ int env_set(HASHTBL *task_tbl, oph_operator_struct *handle)
 	((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_type = NULL;
 	((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->number = 0;
 	((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->execute_error = 0;
+	((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->ensamble_size = -1;
 
 	char **datacube_in;
 	char *value;
@@ -499,17 +500,19 @@ int task_init(oph_operator_struct *handle)
 
 	int pointer, input_datacube_num =
 	    ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->input_datacube_num + ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->number, stream_max_size =
-	    4 + OPH_ODB_CUBE_FRAG_REL_INDEX_SET_SIZE + 2 * sizeof(int) + input_datacube_num * OPH_ODB_CUBE_MEASURE_TYPE_SIZE;
+	    4 + OPH_ODB_CUBE_FRAG_REL_INDEX_SET_SIZE + 3 * sizeof(int) + input_datacube_num * OPH_ODB_CUBE_MEASURE_TYPE_SIZE;
 	char stream[stream_max_size];
 	memset(stream, 0, sizeof(stream));
 	*stream = 0;
-	char *id_string[3], *data_type[input_datacube_num];
+	char *id_string[4], *data_type[input_datacube_num];
 	pointer = 0;
 	id_string[0] = stream + pointer;
 	pointer += 1 + OPH_ODB_CUBE_FRAG_REL_INDEX_SET_SIZE;
 	id_string[1] = stream + pointer;
 	pointer += 1 + sizeof(int);
 	id_string[2] = stream + pointer;
+	pointer += 1 + sizeof(int);
+	id_string[3] = stream + pointer;
 	pointer += 1 + sizeof(int);
 
 	int cc = 0, ccc;
@@ -519,6 +522,21 @@ int task_init(oph_operator_struct *handle)
 	}
 
 	if (handle->proc_rank == 0) {
+
+		// Set dim_name if any
+		char *dim_name = ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name;
+		if (!dim_name) {
+			char dimension_name[OPH_ODB_DIM_DIMENSION_SIZE + 1];
+			snprintf(dimension_name, OPH_ODB_DIM_DIMENSION_SIZE, "d%d", ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[0]);
+			((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name = dim_name = strdup(dimension_name);
+			if (!dim_name) {
+				pmesg(LOG_ERROR, __FILE__, __LINE__, "Unable to set dimension name due to a memory error.\n");
+				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
+					"Unable to set dimension name due to a memory error.\n");
+				goto __OPH_EXIT_1;
+			}
+		}
+
 		ophidiadb *oDB = &((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->oDB;
 		oph_odb_datacube *cube = (oph_odb_datacube *) malloc(((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->input_datacube_num * sizeof(oph_odb_datacube));
 		if (cube == NULL) {
@@ -535,7 +553,7 @@ int task_init(oph_operator_struct *handle)
 		int last_insertd_id = 0;
 		int l, ll;
 
-		//retrieve input datacube
+		// Retrieve input datacube
 		if (oph_odb_cube_retrieve_datacube(oDB, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[0], &cube[0])) {
 			for (cc = 0; cc < ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->input_datacube_num; cc++)
 				oph_odb_cube_free_datacube(&(cube[cc]));
@@ -544,7 +562,7 @@ int task_init(oph_operator_struct *handle)
 			logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0], OPH_LOG_OPH_MERGECUBES_DATACUBE_READ_ERROR, 0);
 			goto __OPH_EXIT_1;
 		}
-		//Read old cube - dimension relation rows
+		// Read old cube - dimension relation rows
 		if (oph_odb_cube_retrieve_cubehasdim_list(oDB, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[0], &cubedims, &number_of_dimensions)) {
 			pmesg(LOG_ERROR, __FILE__, __LINE__, "Unable to retreive datacube1 - dimension relations.\n");
 			logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
@@ -555,6 +573,26 @@ int task_init(oph_operator_struct *handle)
 			free(cubedims);
 			goto __OPH_EXIT_1;
 		}
+		// Read old cube dimensions
+		oph_odb_dimension dim[1 + number_of_dimensions];
+		oph_odb_dimension_instance dim_inst[1 + number_of_dimensions];
+		for (l = 0; l < number_of_dimensions; ++l) {
+			if (oph_odb_dim_retrieve_dimension_instance
+			    (oDB, cubedims[l].id_dimensioninst, dim_inst + l, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[0])) {
+				pmesg(LOG_ERROR, __FILE__, __LINE__, "Error in reading dimension information.\n");
+				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0], OPH_LOG_OPH_MERGECUBES_DIM_READ_ERROR);
+				free(cubedims);
+				goto __OPH_EXIT_1;
+			}
+			if (oph_odb_dim_retrieve_dimension(oDB, dim_inst[l].id_dimension, dim + l, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[0])) {
+				pmesg(LOG_ERROR, __FILE__, __LINE__, "Error in reading dimension information.\n");
+				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0], OPH_LOG_OPH_MERGECUBES_DIM_READ_ERROR);
+				free(cubedims);
+				goto __OPH_EXIT_1;
+			}
+		}
+
+		int found_dim_name = -1;
 		for (cc = 1; cc < ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->input_datacube_num; cc++) {
 			if (oph_odb_cube_retrieve_datacube(oDB, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[cc], &cube[cc])) {
 				for (cc = 0; cc < ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->input_datacube_num; cc++)
@@ -563,6 +601,7 @@ int task_init(oph_operator_struct *handle)
 				pmesg(LOG_ERROR, __FILE__, __LINE__, "Error while retrieving input datacube\n");
 				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
 					OPH_LOG_OPH_MERGECUBES_DATACUBE_READ_ERROR, cc);
+				free(cubedims);
 				goto __OPH_EXIT_1;
 			}
 			// Checking fragmentation structure
@@ -573,6 +612,7 @@ int task_init(oph_operator_struct *handle)
 				pmesg(LOG_ERROR, __FILE__, __LINE__, "Datacube fragmentation structures are not comparable\n");
 				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
 					OPH_LOG_OPH_MERGECUBES_DATACUBE_COMPARISON_ERROR, "fragmentation structures");
+				free(cubedims);
 				goto __OPH_EXIT_1;
 			}
 			// Checking fragment indexes
@@ -583,6 +623,7 @@ int task_init(oph_operator_struct *handle)
 				pmesg(LOG_ERROR, __FILE__, __LINE__, "Datacube relative index sets are not comparable\n");
 				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
 					OPH_LOG_OPH_MERGECUBES_DATACUBE_COMPARISON_ERROR, "relative index sets");
+				free(cubedims);
 				goto __OPH_EXIT_1;
 			}
 
@@ -593,6 +634,7 @@ int task_init(oph_operator_struct *handle)
 				pmesg(LOG_ERROR, __FILE__, __LINE__, "Datacube are compressed differently\n");
 				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
 					OPH_LOG_OPH_MERGECUBES_DATACUBE_COMPARISON_ERROR, "compression methods");
+				free(cubedims);
 				goto __OPH_EXIT_1;
 			}
 
@@ -618,9 +660,32 @@ int task_init(oph_operator_struct *handle)
 				    || (cubedims[l].level != cubedims2[ll].level))
 					break;
 			}
-			for (; l < number_of_dimensions; l++)
-				if (cubedims[l].size)
-					break;
+			found_dim_name = -1;
+			for (; l < number_of_dimensions; l++) {
+				if (cubedims[l].size) {
+					if (found_dim_name < 0) {
+						found_dim_name = l;
+						if (strcmp(dim_name, dim[l].dimension_name)) {
+							pmesg(LOG_WARNING, __FILE__, __LINE__, "A new dimension name '%s' is already set. Input argument '%s' will be negletted\n",
+							      dim[l].dimension_name, dim_name);
+							logging(LOG_WARNING, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
+								"A new dimension name '%s' is already set. Input argument '%s' will be negletted\n", dim[l].dimension_name, dim_name);
+							free(((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name);
+							((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name = dim_name = strdup(dim[l].dimension_name);
+						}
+						if (l < number_of_dimensions - 1) {
+							pmesg(LOG_ERROR, __FILE__, __LINE__, "The ensamble dimension is not the last dimension: currently unsupported!\n");
+							logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
+								"The ensamble dimension is not the last dimension: currently unsupported!\n");
+							free(cube);
+							free(cubedims);
+							free(cubedims2);
+							goto __OPH_EXIT_1;
+						}
+					} else
+						break;
+				}
+			}
 			for (; ll < number_of_dimensions2; ll++)
 				if (cubedims2[ll].size)
 					break;
@@ -770,32 +835,20 @@ int task_init(oph_operator_struct *handle)
 			if (!cubedims[l].explicit_dim && cubedims[l].size)
 				max_level = cubedims[l].level;
 		}
-		cubedims_new[l].id_datacube = cubedims[0].id_datacube;
-		cubedims_new[l].id_dimensioninst = 0;
-		cubedims_new[l].explicit_dim = 0;
-		cubedims_new[l].level = max_level + 1;
-		cubedims_new[l].size = input_datacube_num;
+		if (found_dim_name < 0) {
+			cubedims_new[l].id_datacube = cubedims[0].id_datacube;
+			cubedims_new[l].id_dimensioninst = 0;
+			cubedims_new[l].explicit_dim = 0;
+			cubedims_new[l].level = max_level + 1;
+			cubedims_new[l].size = input_datacube_num;
+		} else {
+			l = found_dim_name;
+			((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->ensamble_size = cubedims_new[l].size;
+			cubedims_new[l].size += input_datacube_num - 1;
+		}
 
 		free(cubedims);
 		cubedims = cubedims_new;
-
-		oph_odb_dimension dim[1 + number_of_dimensions];
-		oph_odb_dimension_instance dim_inst[1 + number_of_dimensions];
-		for (l = 0; l < number_of_dimensions; ++l) {
-			if (oph_odb_dim_retrieve_dimension_instance
-			    (oDB, cubedims[l].id_dimensioninst, &(dim_inst[l]), ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[0])) {
-				pmesg(LOG_ERROR, __FILE__, __LINE__, "Error in reading dimension information.\n");
-				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0], OPH_LOG_OPH_MERGECUBES_DIM_READ_ERROR);
-				free(cubedims);
-				goto __OPH_EXIT_1;
-			}
-			if (oph_odb_dim_retrieve_dimension(oDB, dim_inst[l].id_dimension, &(dim[l]), ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_datacube[0])) {
-				pmesg(LOG_ERROR, __FILE__, __LINE__, "Error in reading dimension information.\n");
-				logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0], OPH_LOG_OPH_MERGECUBES_DIM_READ_ERROR);
-				free(cubedims);
-				goto __OPH_EXIT_1;
-			}
-		}
 
 		oph_odb_db_instance db_;
 		oph_odb_db_instance *db = &db_;
@@ -832,12 +885,7 @@ int task_init(oph_operator_struct *handle)
 			goto __OPH_EXIT_1;
 		}
 		dim[l].id_container = ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_output_container;
-		if (((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name)
-			snprintf(dim[l].dimension_name, OPH_ODB_DIM_DIMENSION_SIZE, "%s", ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name);
-		else {
-			snprintf(dim[l].dimension_name, OPH_ODB_DIM_DIMENSION_SIZE, "d%d", ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_output_datacube);
-			((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name = strdup(dim[l].dimension_name);
-		}
+		snprintf(dim[l].dimension_name, OPH_ODB_DIM_DIMENSION_SIZE, "%s", dim_name);
 		int size = 0;
 		if (oph_dim_check_data_type(((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_type, &size)) {
 			pmesg(LOG_ERROR, __FILE__, __LINE__, "Invalid dimension type %s\n", ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_type);
@@ -872,6 +920,9 @@ int task_init(oph_operator_struct *handle)
 		snprintf(dimension_table_name, OPH_COMMON_BUFFER_LEN, OPH_DIM_TABLE_NAME_MACRO, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0]);
 		char o_dimension_table_name[OPH_COMMON_BUFFER_LEN];
 		snprintf(o_dimension_table_name, OPH_COMMON_BUFFER_LEN, OPH_DIM_TABLE_NAME_MACRO, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_output_container);
+
+		if (found_dim_name >= 0)
+			number_of_dimensions--;
 
 		for (l = 0; l <= number_of_dimensions; l++) {
 			dim_inst[l].size = cubedims[l].size;
@@ -966,8 +1017,8 @@ int task_init(oph_operator_struct *handle)
 						free(dim_array);
 				}
 			} else {
-				if (!strcmp(dim[l].dimension_name, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name)) {
-					pmesg(LOG_ERROR, __FILE__, __LINE__, "Invalid dimension name '%s'.\n", ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->dim_name);
+				if (!strcmp(dim[l].dimension_name, dim_name)) {
+					pmesg(LOG_ERROR, __FILE__, __LINE__, "Invalid dimension name '%s'.\n", dim_name);
 					logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
 						OPH_LOG_OPH_MERGECUBES_DIM_READ_ERROR);
 					if (dim_row)
@@ -1127,6 +1178,7 @@ int task_init(oph_operator_struct *handle)
 		strncpy(id_string[0], ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->fragment_ids, OPH_ODB_CUBE_FRAG_REL_INDEX_SET_SIZE);
 		memcpy(id_string[1], &((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_output_datacube, sizeof(int));
 		memcpy(id_string[2], &((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->compressed, sizeof(int));
+		memcpy(id_string[3], &((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->ensamble_size, sizeof(int));
 
 		for (cc = 0; cc < input_datacube_num; cc++) {
 			strncpy(data_type[cc], ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->measure_type[cc], OPH_ODB_CUBE_MEASURE_TYPE_SIZE);
@@ -1168,6 +1220,7 @@ int task_init(oph_operator_struct *handle)
 		}
 		((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_output_datacube = *((int *) id_string[1]);
 		((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->compressed = *((int *) id_string[2]);
+		((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->ensamble_size = *((int *) id_string[3]);
 	}
 	return OPH_ANALYTICS_OPERATOR_SUCCESS;
 }
@@ -1456,11 +1509,15 @@ int task_execute(oph_operator_struct *handle)
 					       MYSQL_FRAG_MEASURE, frags[0].value[k].db_instance->db_name, frags[0].value[k].fragment_name, frags[1].value[k].db_instance->db_name,
 					       frags[1].value[k].fragment_name, frags[0].value[k].fragment_name, MYSQL_FRAG_ID, frags[1].value[k].fragment_name, MYSQL_FRAG_ID);
 #endif
-
-				fprintf(stderr, "Query: %s§\n", query);
-
+				long long *list = NULL, list_, list_num = 0;
+				if (((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->ensamble_size >= 0) {
+					list_ = ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->ensamble_size;
+					list = &list_;
+					list_num = sizeof(long long);
+				}
 				//MERGECUBES2 fragment
-				if (oph_dc_create_fragment_from_query(((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->server, &(frags[0].value[k]), NULL, query, 0, 0, 0)) {
+				if (oph_dc_create_fragment_from_query_with_param
+				    (((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->server, &(frags[0].value[k]), NULL, query, 0, 0, 0, list, list_num)) {
 					pmesg(LOG_ERROR, __FILE__, __LINE__, "Unable to insert new fragment.\n");
 					logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
 						OPH_LOG_OPH_MERGECUBES_NEW_FRAG_ERROR, frag_name_out);

--- a/src/drivers/OPH_MERGECUBES2_operator.c
+++ b/src/drivers/OPH_MERGECUBES2_operator.c
@@ -1517,7 +1517,7 @@ int task_execute(oph_operator_struct *handle)
 				}
 				//MERGECUBES2 fragment
 				if (oph_dc_create_fragment_from_query_with_param
-				    (((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->server, &(frags[0].value[k]), NULL, query, 0, 0, 0, list, list_num)) {
+				    (((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->server, &(frags[0].value[k]), NULL, query, 0, 0, 0, (char *) list, list_num)) {
 					pmesg(LOG_ERROR, __FILE__, __LINE__, "Unable to insert new fragment.\n");
 					logging(LOG_ERROR, __FILE__, __LINE__, ((OPH_MERGECUBES2_operator_handle *) handle->operator_handle)->id_input_container[0],
 						OPH_LOG_OPH_MERGECUBES_NEW_FRAG_ERROR, frag_name_out);

--- a/src/oph_datacube_library.c
+++ b/src/oph_datacube_library.c
@@ -613,13 +613,13 @@ int oph_dc_create_fragment_from_query2(oph_ioserver_handler *server, oph_odb_fra
 int oph_dc_create_fragment_from_query_with_param(oph_ioserver_handler *server, oph_odb_fragment *old_frag, char *new_frag_name, char *operation, char *where, long long *aggregate_number,
 						 long long *start_id, char *param, long long param_size)
 {
-	return oph_dc_create_fragment_from_query_with_params2(server, old_frag, new_frag_name, operation, where, aggregate_number, start_id, NULL, param, param_size, 1);
+	return oph_dc_create_fragment_from_query_with_params2(server, old_frag, new_frag_name, operation, where, aggregate_number, start_id, NULL, param, param_size, param ? 1 : 0);
 }
 
 int oph_dc_create_fragment_from_query_with_param2(oph_ioserver_handler *server, oph_odb_fragment *old_frag, char *new_frag_name, char *operation, char *where, long long *aggregate_number,
 						  long long *start_id, long long *block_size, char *param, long long param_size)
 {
-	return oph_dc_create_fragment_from_query_with_params2(server, old_frag, new_frag_name, operation, where, aggregate_number, start_id, block_size, param, param_size, 1);
+	return oph_dc_create_fragment_from_query_with_params2(server, old_frag, new_frag_name, operation, where, aggregate_number, start_id, block_size, param, param_size, param ? 1 : 0);
 }
 
 int oph_dc_create_fragment_from_query_with_params(oph_ioserver_handler *server, oph_odb_fragment *old_frag, char *new_frag_name, char *operation, char *where, long long *aggregate_number,
@@ -636,10 +636,6 @@ int oph_dc_create_fragment_from_query_with_params2(oph_ioserver_handler *server,
 	    if (!old_frag || !operation || (!param && param_size) || (param && !param_size) || !server) {
 		pmesg(LOG_ERROR, __FILE__, __LINE__, "Null input parameter\n");
 		return OPH_DC_NULL_PARAM;
-	}
-	if (num < 1) {
-		pmesg(LOG_ERROR, __FILE__, __LINE__, "At least an occurrance of parameter has to be found\n");
-		return OPH_DC_DATA_ERROR;
 	}
 	if (oph_dc_check_connection_to_db(server, old_frag->db_instance->dbms_instance, old_frag->db_instance, 0)) {
 		pmesg(LOG_ERROR, __FILE__, __LINE__, "Unable to reconnect to DB.\n");

--- a/src/ophidiadb/oph_odb_cube_library.c
+++ b/src/ophidiadb/oph_odb_cube_library.c
@@ -1375,7 +1375,7 @@ int oph_odb_cube_order_by(ophidiadb *oDB, int order, int *id_datacube, int id_da
 		return OPH_ODB_NULL_PARAM;
 	}
 
-	if (!order || (id_datacube_num < 2))
+	if (id_datacube_num < 2)
 		return OPH_ODB_SUCCESS;
 
 	int n = 0, cc, nn = 0;
@@ -1395,7 +1395,7 @@ int oph_odb_cube_order_by(ophidiadb *oDB, int order, int *id_datacube, int id_da
 			n = snprintf(query, MYSQL_BUFLEN, MYSQL_QUERY_ORDER_CUBE_BY_SOURCE, cube_list);
 			break;
 		default:
-			return OPH_ODB_SUCCESS;
+			n = snprintf(query, MYSQL_BUFLEN, MYSQL_QUERY_ORDER_CUBE_BY_NDIM, cube_list);
 	}
 	if (n >= MYSQL_BUFLEN) {
 		pmesg(LOG_ERROR, __FILE__, __LINE__, "Size of query exceed query limit.\n");
@@ -1411,15 +1411,15 @@ int oph_odb_cube_order_by(ophidiadb *oDB, int order, int *id_datacube, int id_da
 	MYSQL_ROW row;
 	res = mysql_store_result(oDB->conn);
 
-	if (mysql_field_count(oDB->conn) != 2) {
-		pmesg(LOG_ERROR, __FILE__, __LINE__, "Not enough fields found by query.\n");
+	if (mysql_field_count(oDB->conn) != 3) {
+		pmesg(LOG_ERROR, __FILE__, __LINE__, "Wrong number of fields found by query.\n");
 		mysql_free_result(res);
 		return OPH_ODB_TOO_MANY_ROWS;
 	}
 
 	int num_rows = mysql_num_rows(res);
 	if (num_rows != id_datacube_num) {
-		pmesg(LOG_WARNING, __FILE__, __LINE__, "Cubes cannot be ordered by source.\n");
+		pmesg(LOG_WARNING, __FILE__, __LINE__, "Cubes cannot be ordered.\n");
 		mysql_free_result(res);
 		return OPH_ODB_SUCCESS;
 	}


### PR DESCRIPTION
The OPH_MERGECUBE2 operator is improved by allowing an input cube to have the ensable dimension: the set of its values will be enlarged based on the number of other cubes to be merged.